### PR TITLE
Avoid setting document.domain for CSP sandbox compliance

### DIFF
--- a/src/node/handler/ImportHandler.js
+++ b/src/node/handler/ImportHandler.js
@@ -291,9 +291,6 @@ exports.doImport = function(req, res, padId)
       </head> \
       <script> \
         $(window).load(function(){ \
-          if(navigator.userAgent.indexOf('MSIE') === -1){ \
-            document.domain = document.domain; \
-          } \
           var impexp = window.parent.padimpexp.handleFrameCall('" + directDatabaseAccess +"', '" + status + "'); \
         }) \
       </script>"

--- a/src/static/js/pad.js
+++ b/src/static/js/pad.js
@@ -522,11 +522,6 @@ var pad = {
     pad.initTime = +(new Date());
     pad.padOptions = clientVars.initialOptions;
 
-    if ((!browser.msie) && (!(browser.firefox && browser.version.indexOf("1.8.") == 0)))
-    {
-      document.domain = document.domain; // for comet
-    }
-
     // for IE
     if (browser.msie)
     {

--- a/src/templates/pad.html
+++ b/src/templates/pad.html
@@ -452,9 +452,6 @@
 
               $ = jQuery = require('ep_etherpad-lite/static/js/rjquery').jQuery; // Expose jQuery #HACK
               browser = require('ep_etherpad-lite/static/js/browser').browser;
-              if ((!browser.msie) && (!(browser.mozilla && browser.version.indexOf("1.8.") == 0))) {
-                document.domain = document.domain; // for comet
-              }
 
               var plugins = require('ep_etherpad-lite/static/js/pluginfw/client_plugins');
               var hooks = require('ep_etherpad-lite/static/js/pluginfw/hooks');

--- a/src/templates/timeslider.html
+++ b/src/templates/timeslider.html
@@ -246,10 +246,6 @@
     $ = jQuery = require('ep_etherpad-lite/static/js/rjquery').jQuery; // Expose jQuery #HACK
     browser = require('ep_etherpad-lite/static/js/browser').browser;
 
-    if ((!browser.msie) && (!(browser.mozilla && browser.version.indexOf("1.8.") == 0))) {
-      document.domain = document.domain; // for comet
-    }
-
     var plugins = require('ep_etherpad-lite/static/js/pluginfw/client_plugins');
     var socket = require('ep_etherpad-lite/static/js/timeslider').socket;
     BroadcastSlider = require('ep_etherpad-lite/static/js/timeslider').BroadcastSlider;

--- a/tests/frontend/runner.js
+++ b/tests/frontend/runner.js
@@ -161,12 +161,6 @@ $(function(){
     }
   }
 
-  //allow cross iframe access
-  var browser = bowser;
-  if ((!browser.msie) && (!(browser.mozilla && browser.version.indexOf("1.8.") == 0))) {
-    document.domain = document.domain; // for comet
-  }
-
   //http://stackoverflow.com/questions/1403888/get-url-parameter-with-jquery
   var getURLParameter = function (name) {
     return decodeURI(


### PR DESCRIPTION
The document.domain = document.domain trick appears to only be relevant when
using long-polling on a different subdomain or port, which is never the case
under Sandstorm.  See comment from the author at
http://stackoverflow.com/a/1525312

However, this behavior is problematic when CSP sandboxing - the frame is not
supposed to be able to modify its origin.

Since Sandstorm does not require this behavior, we remove the lines that cause
the app to break when run under a CSP sandbox.
