### PR TITLE
Add shortDescription

### DIFF
--- a/sandstorm-pkgdef.capnp
+++ b/sandstorm-pkgdef.capnp
@@ -59,6 +59,7 @@ const pkgdef :Spk.PackageDefinition = (
       pgpKeyring = embed "pgp-keyring",
 
       description = (defaultText = embed "description.md"),
+      shortDescription = (defaultText = "Document editor"),
 
       screenshots = [
         (width = 448, height = 343, png = embed "sandstorm-screenshot.png")


### PR DESCRIPTION
So that we can link to the Etherpad manifest as an example without the caveat that it's missing a thing.
